### PR TITLE
Fix path to extract-attachments in doc

### DIFF
--- a/README
+++ b/README
@@ -22,7 +22,7 @@ DESCRIPTION
     The files are initially stored in the database when RT receives them;
     this guarantees that the user does not need to wait for the file to be
     transferred to disk or to the cloud, and makes it durable to transient
-    failures of cloud connectivity. The provided bin/extract-attachments
+    failures of cloud connectivity. The provided sbin/extract-attachments
     script, to be run regularly via cron, takes care of moving attachments
     out of the database at a later time.
 
@@ -54,17 +54,17 @@ INSTALLATION
         they are extracted.
 
     Extract existing attachments
-        Run bin/extract-attachments; this may take some time, depending on
+        Run sbin/extract-attachments; this may take some time, depending on
         the existing size of the database. This task may be safely cancelled
         and re-run to resume.
 
     Schedule attachments extraction
-        Schedule bin/extract-attachments to run at regular intervals via
+        Schedule sbin/extract-attachments to run at regular intervals via
         cron. For instance, the following /etc/cron.d/rt entry will run it
         daily, which may be good to concentrate network or disk usage to
         times when RT is less in use:
 
-            0 0 * * * root /opt/rt4/local/plugins/RT-Extension-ExternalStorage/bin/extract-attachments
+            0 0 * * * root /opt/rt4/local/plugins/RT-Extension-ExternalStorage/sbin/extract-attachments
 
 CONFIGURATION
     This module comes with a number of possible backends; see the

--- a/lib/RT/Extension/ExternalStorage.pm
+++ b/lib/RT/Extension/ExternalStorage.pm
@@ -85,7 +85,7 @@ on file contents; this provides de-duplication.
 The files are initially stored in the database when RT receives them;
 this guarantees that the user does not need to wait for the file to be
 transferred to disk or to the cloud, and makes it durable to transient
-failures of cloud connectivity.  The provided C<bin/extract-attachments>
+failures of cloud connectivity.  The provided C<sbin/extract-attachments>
 script, to be run regularly via cron, takes care of moving attachments
 out of the database at a later time.
 
@@ -125,18 +125,18 @@ are extracted.
 
 =item Extract existing attachments
 
-Run C<bin/extract-attachments>; this may take some time, depending on
+Run C<sbin/extract-attachments>; this may take some time, depending on
 the existing size of the database.  This task may be safely cancelled
 and re-run to resume.
 
 =item Schedule attachments extraction
 
-Schedule C<bin/extract-attachments> to run at regular intervals via
+Schedule C<sbin/extract-attachments> to run at regular intervals via
 cron.  For instance, the following F</etc/cron.d/rt> entry will run it
 daily, which may be good to concentrate network or disk usage to times
 when RT is less in use:
 
-    0 0 * * * root /opt/rt4/local/plugins/RT-Extension-ExternalStorage/bin/extract-attachments
+    0 0 * * * root /opt/rt4/local/plugins/RT-Extension-ExternalStorage/sbin/extract-attachments
 
 =back
 

--- a/lib/RT/Extension/ExternalStorage/Disk.pm
+++ b/lib/RT/Extension/ExternalStorage/Disk.pm
@@ -131,7 +131,7 @@ if the same file appears in multiple transactions, only one copy will be
 stored on disk.
 
 The C<Path> must be readable by the webserver, and writable by the
-C<bin/extract-attachments> script.  Because the majority of the
+C<sbin/extract-attachments> script.  Because the majority of the
 attachments are in the filesystem, a simple database backup is thus
 incomplete.  It is B<extremely important> that I<backups include the
 on-disk attachments directory>.


### PR DESCRIPTION
File extract-attachments is installed to sbin, but in documentation was bin directory.
